### PR TITLE
fix: ビルド時のratelimit制限を回避

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ./docker
       dockerfile: Dockerfile
+      ssh:
+        - default
     volumes:
       - type: bind
         source: ../

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ ARG PNPM_HOME="${HOME_DIR}/.local/share/pnpm"
 ARG PATH="$PNPM_HOME:$PATH"
 
 # setup mise and pnpm
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+RUN --mount=type=ssh \
     eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv) && \
     mise install --yes && \
     mise exec -- pnpm config set store-dir ${HOME_DIR}/.pnpm-store && \


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
mise/pnpmのセットアップ時にgithub apiのrate limitでビルドに失敗する場合があるため、sshエージェント経由で実行するように修正しました。

## What

<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

- ratelimitエラーでビルドに失敗後、--mount=type=sshに変更し再ビルド
- 再ビルドが成功することを確認

## Checklist

- [ ] Read CONTRIBUTING.md at the repository.
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
