### PR TITLE
feat: install claude using brew

### DIFF
--- a/docker/Brewfile
+++ b/docker/Brewfile
@@ -1,2 +1,3 @@
 brew 'mise'
 brew 'vim'
+cask 'claude-code'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,10 +56,10 @@ ARG USERNAME=kintone
 ARG HOME_DIR=/home/${USERNAME}
 RUN groupadd --gid $USER_GID $USERNAME && \
     useradd -s /bin/zsh --uid $USER_UID --gid $USER_GID -m $USERNAME && \
-    mkdir -p ${HOME_DIR}/.claude /workspace/node_modules /pnpm /commandhistory /usr/local/share/npm-global /usr/local/bin/mise && \
+    mkdir -p ${HOME_DIR}/.claude /workspace/node_modules /pnpm /commandhistory /usr/local/share/npm-global /usr/local/bin/mise ${HOME_DIR}/.config && \
     touch /usr/local/etc/npmrc /commandhistory/.zsh_history && \
     git clone --depth 1 https://github.com/zsh-users/zsh-completions.git "${ZDOTDIR:-${HOME_DIR}}/.zsh-completions" && \
-    chown -R ${USER_UID}:${USER_GID} ${HOME_DIR}/.claude /workspace/node_modules /pnpm /usr/local/etc/npmrc /commandhistory /usr/local
+    chown -R ${USER_UID}:${USER_GID} ${HOME_DIR}/.claude /workspace/node_modules /pnpm /usr/local/etc/npmrc /commandhistory /usr/local ${HOME_DIR}/.config
 
 # copy zshrc file
 COPY --chown=${USER_UID}:${USER_GID} .zshrc ${HOME_DIR}/
@@ -82,18 +82,12 @@ RUN eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv) && \
     rm -rf $(brew --cache) && \
     rm -rf ${HOME_DIR}/Brewfile
 
+# install baseline tools from /mise/config.toml
+RUN eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv) && \
+    mise install --yes
+
 ARG PNPM_HOME="${HOME_DIR}/.local/share/pnpm"
 ARG PATH="$PNPM_HOME:$PATH"
-
-# setup mise and pnpm
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
-    eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv) && \
-    mise install --yes && \
-    mise exec -- pnpm config set store-dir ${HOME_DIR}/.pnpm-store && \
-    mise exec -- pnpm config set minimumReleaseAge 1440 && \
-    mise exec -- npm config set ignore-scripts true --global && \
-    mise exec -- pnpm add -g @anthropic-ai/claude-code && \
-    mise cache clear
 
 WORKDIR /workspace
 

--- a/scripts/post-create.sh
+++ b/scripts/post-create.sh
@@ -2,3 +2,12 @@
 
 # remove ssh program settings for host env
 git config --global --unset gpg.ssh.program || true
+
+# install project-specific tools from workspace mise.toml
+mise install --yes
+
+# setup pnpm configs
+mise exec -- pnpm config set store-dir /home/kintone/.pnpm-store
+mise exec -- pnpm config set minimumReleaseAge 1440
+mise exec -- npm config set ignore-scripts true --global
+mise cache clear


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

  ## Why

  <!-- Why do you want the feature and why does it make sense for the package? -->
  Clarify the separation of responsibilities between Dockerfile and post-create.sh to reduce container startup time and improve build cache efficiency. Also, switch to installing Claude Code via Homebrew.

  ## What

  <!-- What is a solution you want to add? -->
  - Add `claude-code` to Brewfile (install via Homebrew cask)
  - Pre-install baseline tools (node, pnpm) in Dockerfile
  - Move pnpm configuration to post-create.sh (volume mount dependent)
  - Add `${HOME_DIR}/.config` directory to mkdir and chown targets
  - Remove GITHUB_TOKEN secret mount from Dockerfile


## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read CONTRIBUTING.md at the repository.
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
