### PR TITLE
feat: use published container image

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,25 @@
+name: publish-image
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable-build-image.yaml
+    with:
+      push: true
+      tags: ghcr.io/kintone/dev-container:latest
+
+  yamory-scan:
+    needs: build
+    uses: ./.github/workflows/reusable-yamory-scan.yaml
+    with:
+      image_name: ghcr.io/kintone/dev-container:latest
+      image_title: dev-container
+      image_identifier: dev-container
+    secrets:
+      YAMORY_API_KEY: ${{ secrets.YAMORY_API_KEY }}

--- a/.github/workflows/reusable-build-image.yaml
+++ b/.github/workflows/reusable-build-image.yaml
@@ -1,0 +1,49 @@
+name: reusable-build-image
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: "Whether to push the image (requires packages: write permission from caller if true)"
+        required: false
+        type: boolean
+        default: false
+      tags:
+        description: "Image tags (e.g., ghcr.io/org/repo:latest)"
+        required: false
+        type: string
+        default: ""
+
+defaults:
+  run:
+    shell: bash -eo pipefail {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Login to GitHub Container Registry
+        if: inputs.push
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          provenance: false
+          # Build for both amd64 and arm64
+          platforms: "linux/amd64,linux/arm64"
+          push: ${{ inputs.push }}
+          tags: ${{ inputs.tags }}
+        env:
+          DOCKER_BUILD_SUMMARY: false

--- a/.github/workflows/reusable-yamory-scan.yaml
+++ b/.github/workflows/reusable-yamory-scan.yaml
@@ -1,0 +1,66 @@
+name: reusable-yamory-scan
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: "Target image name to scan (e.g., ghcr.io/org/repo:tag)"
+        required: true
+        type: string
+      image_title:
+        description: "YAMORY_IMAGE_TITLE"
+        required: true
+        type: string
+      image_identifier:
+        description: "YAMORY_IMAGE_IDENTIFIER"
+        required: true
+        type: string
+      image_tags:
+        description: "YAMORY_IMAGE_TAGS (defaults to image_title if not specified)"
+        required: false
+        type: string
+    secrets:
+      YAMORY_API_KEY:
+        required: true
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup trivy
+        env:
+          TRIVY_VERSION: 0.36.1
+          TRIVY_CHECKSUM: 332da8e456e2ae1b5bc02ba7e7c24d2210e04ce06c67bef1f43fe4fec4482875
+        run: |
+          wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
+          echo "${TRIVY_CHECKSUM}  trivy_${TRIVY_VERSION}_Linux-64bit.deb" > trivy-sha256sum.txt
+          sha256sum -c trivy-sha256sum.txt
+          sudo dpkg -i trivy_${TRIVY_VERSION}_Linux-64bit.deb
+
+      - name: Login to GHCR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Container image scan with yamory and trivy
+        env:
+          IMAGE_SCAN_CHECKSUM: 6c5d4ffcc2e88a6f879166179e9d511cd00e45dc9e05e7a41a21db419d5103cf81d0a2350d6e113d8666652906d836f02ab0e441c53e6a5fbdd51b6704c05f30
+          YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_API_KEY }}
+          YAMORY_IMAGE_NAME: ${{ inputs.image_name }}
+        run: |
+          curl -sSf -L -o image_scan.sh https://mw-receiver.yamory.io/image/script/trivy
+          echo "${IMAGE_SCAN_CHECKSUM} image_scan.sh" > image_scan_sha512sum.txt
+          sha512sum -c image_scan_sha512sum.txt
+          chmod +x image_scan.sh
+
+          YAMORY_IMAGE_TITLE=${{ inputs.image_title }} \
+          YAMORY_OPEN_CONTAINER=false \
+          YAMORY_IMAGE_TAGS=${{ inputs.image_tags || inputs.image_title }} \
+          YAMORY_IMAGE_IDENTIFIER=${{ inputs.image_identifier }} \
+          bash image_scan.sh

--- a/.github/workflows/reusable-yamory-scan.yaml
+++ b/.github/workflows/reusable-yamory-scan.yaml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Setup trivy
         env:
-          TRIVY_VERSION: 0.36.1
-          TRIVY_CHECKSUM: 332da8e456e2ae1b5bc02ba7e7c24d2210e04ce06c67bef1f43fe4fec4482875
+          TRIVY_VERSION: 0.68.2
+          TRIVY_CHECKSUM: 68b3c0350490456f56fbf8ea604663c79af73f628f4c3bb0fd76bfcc26fafea6
         run: |
           wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
           echo "${TRIVY_CHECKSUM}  trivy_${TRIVY_VERSION}_Linux-64bit.deb" > trivy-sha256sum.txt

--- a/.github/workflows/reusable-yamory-scan.yaml
+++ b/.github/workflows/reusable-yamory-scan.yaml
@@ -53,14 +53,14 @@ jobs:
           IMAGE_SCAN_CHECKSUM: 6c5d4ffcc2e88a6f879166179e9d511cd00e45dc9e05e7a41a21db419d5103cf81d0a2350d6e113d8666652906d836f02ab0e441c53e6a5fbdd51b6704c05f30
           YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_API_KEY }}
           YAMORY_IMAGE_NAME: ${{ inputs.image_name }}
+          YAMORY_IMAGE_TITLE: ${{ inputs.image_title }}
+          YAMORY_IMAGE_TAGS: ${{ inputs.image_tags || inputs.image_title }}
+          YAMORY_IMAGE_IDENTIFIER: ${{ inputs.image_identifier }}
+          YAMORY_OPEN_CONTAINER: false
         run: |
           curl -sSf -L -o image_scan.sh https://mw-receiver.yamory.io/image/script/trivy
           echo "${IMAGE_SCAN_CHECKSUM} image_scan.sh" > image_scan_sha512sum.txt
           sha512sum -c image_scan_sha512sum.txt
           chmod +x image_scan.sh
 
-          YAMORY_IMAGE_TITLE=${{ inputs.image_title }} \
-          YAMORY_OPEN_CONTAINER=false \
-          YAMORY_IMAGE_TAGS=${{ inputs.image_tags || inputs.image_title }} \
-          YAMORY_IMAGE_IDENTIFIER=${{ inputs.image_identifier }} \
           bash image_scan.sh

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,6 +1,7 @@
 name: test-build
 on:
   pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,9 @@
+name: test-build
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build-image.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ services:
     build:
       context: ./docker
       dockerfile: Dockerfile
-   pull_policy: build
+    pull_policy: build
 ```
 
 設定変更後、Dev Containerを再ビルドして起動します：

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,23 @@ ln -s . .devcontainer
 
 このシンボリックリンクは`.gitignore`に登録されているため、コミットされません。
 
+## ローカル開発用のイメージビルド
+
+デフォルトではGitHub Container Registry (`ghcr.io/kintone/dev-container:latest`) から事前ビルド済みのイメージを使用しますが、Dockerfileを修正してローカルで開発する場合は、ローカルビルドに切り替えることができます。
+
+`docker-compose.local.yml`を作成し、以下の内容を追加します：
+
+```yaml
+services:
+  app:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile
+   pull_policy: build
+```
+
+設定変更後、Dev Containerを再ビルドして起動します：
+
 ## テスト
 
 開発後は、実際のプロジェクトでサブモジュールとして導入し、正常に動作することを確認してください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   app:
-    build:
-      context: ./docker
-      dockerfile: Dockerfile
+    image: ghcr.io/kintone/dev-container:latest
+    pull_policy: always
     volumes:
       - type: bind
         source: ../


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

  ## Why

  <!-- Why do you want the feature and why does it make sense for the package? -->
  Automate container image build, publish, and security scanning in CI/CD to eliminate the need for developers to build images locally. Additionally, by automatically running yamory security scans when images are published, vulnerabilities can be detected early.

  ## What

  <!-- What is a solution you want to add? -->
  - `reusable-build-image.yaml`: Add reusable Docker image build workflow
  - `reusable-yamory-scan.yaml`: Add reusable yamory scan workflow
  - `publish-image.yaml`: Add workflow to build, publish, and scan images on push to main branch
  - `test-build.yaml`: Add workflow to test if build passes on PRs
  - `docker-compose.yml`: Change from local build to using published image from GHCR
  - `CONTRIBUTING.md`: Add documentation for local development build instructions

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read CONTRIBUTING.md at the repository.
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
