### PR TITLE
feat: use local build instead of published image

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,8 +1,12 @@
 name: publish-image
+
+# TODO: CIが修正されたらトリガーを元に戻す
+# on:
+#   push:
+#     branches:
+#       - main
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,9 +1,13 @@
 name: test-build
+
+# TODO: CIが修正されたらトリガーを元に戻す
+# on:
+#   pull_request:
+#   push:
+#     branches:
+#       - main
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,23 +12,6 @@ ln -s . .devcontainer
 
 このシンボリックリンクは`.gitignore`に登録されているため、コミットされません。
 
-## ローカル開発用のイメージビルド
-
-デフォルトではGitHub Container Registry (`ghcr.io/kintone/dev-container:latest`) から事前ビルド済みのイメージを使用しますが、Dockerfileを修正してローカルで開発する場合は、ローカルビルドに切り替えることができます。
-
-`docker-compose.local.yml`を作成し、以下の内容を追加します：
-
-```yaml
-services:
-  app:
-    build:
-      context: ./docker
-      dockerfile: Dockerfile
-    pull_policy: build
-```
-
-設定変更後、Dev Containerを再ビルドして起動します：
-
 ## テスト
 
 開発後は、実際のプロジェクトでサブモジュールとして導入し、正常に動作することを確認してください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   app:
-    image: ghcr.io/kintone/dev-container:latest
-    pull_policy: always
+    build:
+      context: ./docker
+      dockerfile: Dockerfile
     volumes:
       - type: bind
         source: ../


### PR DESCRIPTION
## Why

#5 で導入したpublished container imageを使う方式がCIの問題でビルドに失敗する状態でマージされていたため、一時的にローカルビルド方式に戻す。
## What

- `docker-compose.yml`: published image (`ghcr.io/kintone/dev-container:latest`) からローカルビルド方式に変更
- `publish-image.yaml`: トリガーを `workflow_dispatch` のみに変更（手動実行のみ）
- `test-build.yaml`: トリガーを `workflow_dispatch` のみに変更（手動実行のみ）
- `CONTRIBUTING.md`: ローカルビルド用の説明セクションを削除（不要になったため）
- 各ワークフローに `TODO: CIが修正されたらトリガーを元に戻す` コメントを追加
## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read CONTRIBUTING.md at the repository.
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
