### PR TITLE
chore: update trivy to v0.69.3

### DIFF
--- a/.github/workflows/reusable-yamory-scan.yaml
+++ b/.github/workflows/reusable-yamory-scan.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Setup trivy
         env:
           # renovate: datasource=github-release-attachments depName=aquasecurity/trivy
-          TRIVY_VERSION: v0.68.2
-          TRIVY_SHA256: 68b3c0350490456f56fbf8ea604663c79af73f628f4c3bb0fd76bfcc26fafea6
+          TRIVY_VERSION: v0.69.3
+          TRIVY_SHA256: a484057aafde31089cf2558ca0f79a4bc835125a5ee6834183a5bcf0735af358
         run: |
           TRIVY_DEB="trivy_${TRIVY_VERSION#v}_Linux-64bit.deb"
           wget "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/${TRIVY_DEB}"


### PR DESCRIPTION
## Why

Keep the trivy vulnerability scanner up-to-date to ensure we have the latest security vulnerability database and bug fixes.

## What

- Update trivy from v0.68.2 to v0.69.3
- Update SHA256 checksum for the new version

## How to test

1. Trigger a workflow that uses `reusable-yamory-scan.yaml`
2. Verify that trivy is downloaded and installed successfully
3. Confirm the SHA256 checksum validation passes

